### PR TITLE
Use npm ci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM node:14-alpine3.15 AS BUILD
 WORKDIR /build
 COPY . .
-RUN npm isntall-clean
+RUN npm ci
 RUN npm run build
 
 # Prod stage: gets dist generated in the previous stage and install prod deps to be able to run the application


### PR DESCRIPTION
`isntall` is a typo (that happens to be tolerated by `npm`). There's no particular need to retain this typo...